### PR TITLE
Simplify the shuffleAll() method

### DIFF
--- a/app/src/main/java/com/naman14/timber/MusicPlayer.java
+++ b/app/src/main/java/com/naman14/timber/MusicPlayer.java
@@ -506,27 +506,19 @@ public class MusicPlayer {
 
     public static void shuffleAll(final Context context) {
         Cursor cursor = SongLoader.makeSongCursor(context, null, null);
-        final long[] mTrackList = SongLoader.getSongListForCursor(cursor);
-        final int position = 0;
-        if (mTrackList.length == 0 || mService == null) {
+        final long[] trackList = SongLoader.getSongListForCursor(cursor);
+        if (trackList.length == 0 || mService == null) {
             return;
         }
         try {
             mService.setShuffleMode(MusicService.SHUFFLE_NORMAL);
-            final long mCurrentId = mService.getAudioId();
-            final int mCurrentQueuePosition = getQueuePosition();
-            if (position != -1 && mCurrentQueuePosition == position
-                    && mCurrentId == mTrackList[position]) {
-                final long[] mPlaylist = getQueue();
-                if (Arrays.equals(mTrackList, mPlaylist)) {
+            if (getQueuePosition() == 0 && mService.getAudioId() == trackList[0] && Arrays.equals(trackList, getQueue())) {
                     mService.play();
                     return;
-                }
             }
-            mService.open(mTrackList, -1, -1, IdType.NA.mId);
+            mService.open(trackList, -1, -1, IdType.NA.mId);
             mService.play();
             cursor.close();
-            cursor = null;
         } catch (final RemoteException ignored) {
         }
     }


### PR DESCRIPTION
It still does exactly the same thing, but now without tons of superfluous steps.