### PR TITLE
Avoid the build failing due to missing license/API keys missing.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,8 @@ android {
         //renderscript support mode is not supported for 21+ with gradle version 2.0
         renderscriptTargetApi 20
         renderscriptSupportModeEnabled true
+        resValue "string", "fabric_api_key", "REPLACE ME"
+        resValue "string", "play_billing_license_key", "REPLACE ME"
     }
     buildTypes {
         release {


### PR DESCRIPTION
This makes it more obvious to find out where to set the keys.