### PR TITLE
Update TrackSelector lib and only supply Uris instead of loaded Bitmaps

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp-urlconnection:2.3.0'
     compile 'com.squareup.okhttp:okhttp:2.3.0'
     compile 'com.google.code.gson:gson:2.3'
-    compile 'de.Maxr1998:track-selector-lib:1.1'
+    compile 'de.Maxr1998:track-selector-lib:1.2'
 
     compile 'com.afollestad.material-dialogs:core:0.9.0.2'
     compile 'com.afollestad.material-dialogs:commons:0.9.0.2'

--- a/app/src/main/java/com/naman14/timber/MusicService.java
+++ b/app/src/main/java/com/naman14/timber/MusicService.java
@@ -1193,8 +1193,7 @@ public class MusicService extends Service {
                 ArrayList<Bundle> list = new ArrayList<>();
                 do {
                     TrackItem t = new TrackItem()
-                            .setArt(ImageLoader.getInstance()
-                                    .loadImageSync(TimberUtils.getAlbumArtUri(c.getLong(c.getColumnIndexOrThrow(AudioColumns.ALBUM_ID))).toString()))
+                            .setArt(TimberUtils.getAlbumArtUri(c.getLong(c.getColumnIndexOrThrow(AudioColumns.ALBUM_ID))))
                             .setTitle(c.getString(c.getColumnIndexOrThrow(AudioColumns.TITLE)))
                             .setArtist(c.getString(c.getColumnIndexOrThrow(AudioColumns.ARTIST)))
                             .setDuration(TimberUtils.makeShortTimeString(this, c.getInt(c.getColumnIndexOrThrow(AudioColumns.DURATION)) / 1000));


### PR DESCRIPTION
This change extremely improves performance, as the cover loading is handled on demand inside the Notification, also using a Bitmap cache to keep scrolling smooth. Users need to update to XMNTS 1.2 for that to work though.