### PR TITLE
Show album year when listing albums of an artist

### DIFF
--- a/app/src/main/java/com/naman14/timber/adapters/ArtistAlbumAdapter.java
+++ b/app/src/main/java/com/naman14/timber/adapters/ArtistAlbumAdapter.java
@@ -58,7 +58,12 @@ public class ArtistAlbumAdapter extends RecyclerView.Adapter<ArtistAlbumAdapter.
 
         itemHolder.title.setText(localItem.title);
         String songCount = TimberUtils.makeLabel(mContext, R.plurals.Nsongs, localItem.songCount);
-        itemHolder.details.setText(songCount);
+        String albumYear = Integer.toString(localItem.year);
+
+        if (localItem.hasYear())
+            itemHolder.details.setText(albumYear + " - " + songCount);
+        else
+            itemHolder.details.setText(songCount);
 
         ImageLoader.getInstance().displayImage(TimberUtils.getAlbumArtUri(localItem.id).toString(), itemHolder.albumArt,
                 new DisplayImageOptions.Builder().cacheInMemory(true)

--- a/app/src/main/java/com/naman14/timber/models/Album.java
+++ b/app/src/main/java/com/naman14/timber/models/Album.java
@@ -15,6 +15,8 @@
 package com.naman14.timber.models;
 
 public class Album {
+    public static final int YEAR_UNDEFINED = 0;
+
     public final long artistId;
     public final String artistName;
     public final long id;
@@ -41,4 +43,7 @@ public class Album {
     }
 
 
+    public boolean hasYear() {
+        return year != Album.YEAR_UNDEFINED;
+    }
 }


### PR DESCRIPTION
If you are a music enthusiastic knowing the year of an album is important. You usually want to play albums in chronological order. It also helps to put the album into temporal context.

This pull request is supposed to go on top of #282. Otherwise, there might not be enough space for the year and the song count.