### PR TITLE
Allow to search videos for the current song

### DIFF
--- a/app/src/main/java/com/naman14/timber/nowplaying/BaseNowplayingFragment.java
+++ b/app/src/main/java/com/naman14/timber/nowplaying/BaseNowplayingFragment.java
@@ -15,6 +15,7 @@
 package com.naman14.timber.nowplaying;
 
 import android.animation.ObjectAnimator;
+import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.PorterDuff;
 import android.os.AsyncTask;
@@ -30,7 +31,9 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
-import android.util.Log;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.SeekBar;
@@ -219,6 +222,51 @@ public class BaseNowplayingFragment extends Fragment implements MusicStateListen
         super.onCreate(savedInstanceState);
         ateKey = Helpers.getATEKey(getActivity());
         accentColor = Config.accentColor(getActivity(), ateKey);
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        setHasOptionsMenu(true);
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        super.onCreateOptionsMenu(menu, inflater);
+        inflater.inflate(R.menu.now_playing, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.action_search_videos:
+                pauseMusicPlayer();
+                openSongSearchOnYouTubeApp();
+                break;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void pauseMusicPlayer() {
+        if (MusicPlayer.isPlaying()) {
+            Handler handler = new Handler();
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    MusicPlayer.playOrPause();
+                    if (recyclerView != null && recyclerView.getAdapter() != null)
+                        recyclerView.getAdapter().notifyDataSetChanged();
+                }
+            }, 250);
+        }
+    }
+
+    private void openSongSearchOnYouTubeApp() {
+        Intent intent = new Intent(Intent.ACTION_SEARCH);
+        intent.setPackage("com.google.android.youtube");
+        intent.putExtra("query", MusicPlayer.getArtistName() + " " + MusicPlayer.getTrackName());
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(intent);
     }
 
     @Override

--- a/app/src/main/res/menu/now_playing.xml
+++ b/app/src/main/res/menu/now_playing.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_search_videos"
+        android:title="@string/search_videos" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,4 +156,5 @@
 
     <string name="cancel">Cancel</string>
 
+    <string name="search_videos">Search Videos</string>
 </resources>


### PR DESCRIPTION
It opens the YouTube application with a search of the song that's currently playing.

My original idea was to show the video of the song embedded in the application. That would be done showing the first video in the search results of the song. However, more often than not, the first one is not the official video for the song. Usually being just a static image instead of a real video. This happened even with well-known songs.

Also, I thought that showing search results instead of directly a video allows users to better choose what they really want. For example, sometimes I like to watch live performances of a song instead of its video clip.