### PR TITLE
Download missing album art from Lastfm

### DIFF
--- a/app/src/main/java/com/naman14/timber/TimberApp.java
+++ b/app/src/main/java/com/naman14/timber/TimberApp.java
@@ -15,7 +15,6 @@
 package com.naman14.timber;
 
 import android.app.Application;
-import android.content.Context;
 
 import com.afollestad.appthemeengine.ATE;
 import com.crashlytics.android.Crashlytics;
@@ -57,7 +56,8 @@ public class TimberApp extends Application {
 
             @Override
             protected InputStream getStreamFromNetwork(String imageUri, Object extra) throws IOException {
-                if (prefs.loadArtistImages()) return super.getStreamFromNetwork(imageUri, extra);
+                if (prefs.loadArtistAndAlbumImages())
+                    return super.getStreamFromNetwork(imageUri, extra);
                 throw new IOException();
             }
         }).build();

--- a/app/src/main/java/com/naman14/timber/adapters/ArtistAlbumAdapter.java
+++ b/app/src/main/java/com/naman14/timber/adapters/ArtistAlbumAdapter.java
@@ -26,10 +26,9 @@ import android.widget.TextView;
 
 import com.naman14.timber.R;
 import com.naman14.timber.models.Album;
+import com.naman14.timber.utils.ImageUtils;
 import com.naman14.timber.utils.NavigationUtils;
 import com.naman14.timber.utils.TimberUtils;
-import com.nostra13.universalimageloader.core.DisplayImageOptions;
-import com.nostra13.universalimageloader.core.ImageLoader;
 
 import java.util.List;
 
@@ -60,11 +59,7 @@ public class ArtistAlbumAdapter extends RecyclerView.Adapter<ArtistAlbumAdapter.
         String songCount = TimberUtils.makeLabel(mContext, R.plurals.Nsongs, localItem.songCount);
         itemHolder.details.setText(songCount);
 
-        ImageLoader.getInstance().displayImage(TimberUtils.getAlbumArtUri(localItem.id).toString(), itemHolder.albumArt,
-                new DisplayImageOptions.Builder().cacheInMemory(true)
-                        .showImageOnFail(R.drawable.ic_empty_music2)
-                        .resetViewBeforeLoading(true)
-                        .build());
+        ImageUtils.loadAlbumArtIntoView(localItem.id, itemHolder.albumArt);
 
         if (TimberUtils.isLollipop())
             itemHolder.albumArt.setTransitionName("transition_album_art" + i);

--- a/app/src/main/java/com/naman14/timber/fragments/AlbumDetailFragment.java
+++ b/app/src/main/java/com/naman14/timber/fragments/AlbumDetailFragment.java
@@ -53,13 +53,12 @@ import com.naman14.timber.utils.ATEUtils;
 import com.naman14.timber.utils.Constants;
 import com.naman14.timber.utils.FabAnimationUtils;
 import com.naman14.timber.utils.Helpers;
+import com.naman14.timber.utils.ImageUtils;
 import com.naman14.timber.utils.NavigationUtils;
 import com.naman14.timber.utils.PreferencesUtility;
 import com.naman14.timber.utils.SortOrder;
 import com.naman14.timber.utils.TimberUtils;
 import com.naman14.timber.widgets.DividerItemDecoration;
-import com.nostra13.universalimageloader.core.DisplayImageOptions;
-import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.assist.FailReason;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingListener;
 
@@ -171,11 +170,7 @@ public class AlbumDetailFragment extends Fragment {
     }
 
     private void setAlbumart() {
-        ImageLoader.getInstance().displayImage(TimberUtils.getAlbumArtUri(albumID).toString(), albumArt,
-                new DisplayImageOptions.Builder().cacheInMemory(true)
-                        .showImageOnFail(R.drawable.ic_empty_music2)
-                        .resetViewBeforeLoading(true)
-                        .build(), new ImageLoadingListener() {
+        ImageUtils.loadAlbumArtIntoView(album.id, albumArt, new ImageLoadingListener() {
                     @Override
                     public void onLoadingStarted(String imageUri, View view) {
                     }
@@ -188,7 +183,6 @@ public class AlbumDetailFragment extends Fragment {
                                 .setColor(TimberUtils.getBlackWhiteColor(Config.accentColor(context, Helpers.getATEKey(context))));
                         ATEUtils.setFabBackgroundTint(fab, Config.accentColor(context, Helpers.getATEKey(context)));
                         fab.setImageDrawable(builder.build());
-
                     }
 
                     @Override
@@ -359,5 +353,4 @@ public class AlbumDetailFragment extends Fragment {
         }
 
     }
-
 }

--- a/app/src/main/java/com/naman14/timber/lastfmapi/LastFmClient.java
+++ b/app/src/main/java/com/naman14/timber/lastfmapi/LastFmClient.java
@@ -19,6 +19,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 
+import com.naman14.timber.lastfmapi.callbacks.AlbuminfoListener;
 import com.naman14.timber.lastfmapi.callbacks.ArtistInfoListener;
 import com.naman14.timber.lastfmapi.callbacks.UserListener;
 import com.naman14.timber.lastfmapi.models.AlbumInfo;
@@ -33,13 +34,10 @@ import com.naman14.timber.lastfmapi.models.UserLoginQuery;
 import com.naman14.timber.utils.PreferencesUtility;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 import retrofit.Callback;
@@ -103,16 +101,16 @@ public class LastFmClient {
 
     }
 
-    public void getAlbumInfo(AlbumQuery albumQuery) {
+    public void getAlbumInfo(AlbumQuery albumQuery, final AlbuminfoListener listener) {
         mRestService.getAlbumInfo(albumQuery.mArtist, albumQuery.mALbum, new Callback<AlbumInfo>() {
             @Override
             public void success(AlbumInfo albumInfo, Response response) {
-
+                listener.albumInfoSucess(albumInfo.mAlbum);
             }
 
             @Override
             public void failure(RetrofitError error) {
-
+                listener.albumInfoFailed();
                 error.printStackTrace();
             }
         });

--- a/app/src/main/java/com/naman14/timber/lastfmapi/LastFmClient.java
+++ b/app/src/main/java/com/naman14/timber/lastfmapi/LastFmClient.java
@@ -19,7 +19,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 
-import com.naman14.timber.lastfmapi.callbacks.AlbuminfoListener;
+import com.naman14.timber.lastfmapi.callbacks.AlbumInfoListener;
 import com.naman14.timber.lastfmapi.callbacks.ArtistInfoListener;
 import com.naman14.timber.lastfmapi.callbacks.UserListener;
 import com.naman14.timber.lastfmapi.models.AlbumInfo;
@@ -101,11 +101,11 @@ public class LastFmClient {
 
     }
 
-    public void getAlbumInfo(AlbumQuery albumQuery, final AlbuminfoListener listener) {
+    public void getAlbumInfo(AlbumQuery albumQuery, final AlbumInfoListener listener) {
         mRestService.getAlbumInfo(albumQuery.mArtist, albumQuery.mALbum, new Callback<AlbumInfo>() {
             @Override
             public void success(AlbumInfo albumInfo, Response response) {
-                listener.albumInfoSucess(albumInfo.mAlbum);
+                listener.albumInfoSuccess(albumInfo.mAlbum);
             }
 
             @Override

--- a/app/src/main/java/com/naman14/timber/lastfmapi/RestServiceFactory.java
+++ b/app/src/main/java/com/naman14/timber/lastfmapi/RestServiceFactory.java
@@ -18,16 +18,10 @@ import android.content.Context;
 
 import com.naman14.timber.utils.PreferencesUtility;
 import com.squareup.okhttp.Cache;
-import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Response;
 
-import java.io.IOException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-import okio.BufferedSink;
-import okio.DeflaterSink;
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
 import retrofit.client.OkClient;
@@ -49,7 +43,7 @@ public class RestServiceFactory {
             @Override
             public void intercept(RequestFacade request) {
                 //7-days cache
-                request.addHeader("Cache-Control", String.format("max-age=%d,%smax-stale=%d", Integer.valueOf(60 * 60 * 24 * 7), prefs.loadArtistImages() ? "" : "only-if-cached,", Integer.valueOf(31536000)));
+                request.addHeader("Cache-Control", String.format("max-age=%d,%smax-stale=%d", Integer.valueOf(60 * 60 * 24 * 7), prefs.loadArtistAndAlbumImages() ? "" : "only-if-cached,", Integer.valueOf(31536000)));
                 request.addHeader("Connection", "keep-alive");
             }
         };

--- a/app/src/main/java/com/naman14/timber/lastfmapi/callbacks/AlbumInfoListener.java
+++ b/app/src/main/java/com/naman14/timber/lastfmapi/callbacks/AlbumInfoListener.java
@@ -16,9 +16,9 @@ package com.naman14.timber.lastfmapi.callbacks;
 
 import com.naman14.timber.lastfmapi.models.LastfmAlbum;
 
-public interface AlbuminfoListener {
+public interface AlbumInfoListener {
 
-    void albumInfoSucess(LastfmAlbum album);
+    void albumInfoSuccess(LastfmAlbum album);
 
     void albumInfoFailed();
 

--- a/app/src/main/java/com/naman14/timber/lastfmapi/models/LastfmAlbum.java
+++ b/app/src/main/java/com/naman14/timber/lastfmapi/models/LastfmAlbum.java
@@ -14,5 +14,15 @@
 
 package com.naman14.timber.lastfmapi.models;
 
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
 public class LastfmAlbum {
+    private static final String IMAGE = "image";
+
+    @SerializedName(IMAGE)
+    public List<Artwork> mArtwork;
+
+    // Only needed fields have been defined. See https://www.last.fm/api/show/album.getInfo
 }

--- a/app/src/main/java/com/naman14/timber/utils/ImageUtils.java
+++ b/app/src/main/java/com/naman14/timber/utils/ImageUtils.java
@@ -20,11 +20,77 @@ import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.support.v8.renderscript.RenderScript;
+import android.view.View;
+import android.widget.ImageView;
+
+import com.naman14.timber.R;
+import com.naman14.timber.dataloaders.AlbumLoader;
+import com.naman14.timber.lastfmapi.LastFmClient;
+import com.naman14.timber.lastfmapi.callbacks.AlbuminfoListener;
+import com.naman14.timber.lastfmapi.models.AlbumQuery;
+import com.naman14.timber.lastfmapi.models.LastfmAlbum;
+import com.naman14.timber.models.Album;
+import com.nostra13.universalimageloader.core.DisplayImageOptions;
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.assist.FailReason;
+import com.nostra13.universalimageloader.core.listener.ImageLoadingListener;
+import com.nostra13.universalimageloader.core.listener.SimpleImageLoadingListener;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
 public class ImageUtils {
+    private static final DisplayImageOptions lastfmDisplayImageOptions =
+                                                new DisplayImageOptions.Builder()
+                                                        .cacheInMemory(true)
+                                                        .cacheOnDisk(true)
+                                                        .showImageOnFail(R.drawable.ic_empty_music2)
+                                                        .build();
+
+    private static final DisplayImageOptions diskDisplayImageOptions =
+                                                new DisplayImageOptions.Builder()
+                                                        .cacheInMemory(true)
+                                                        .build();
+
+    public static void loadAlbumArtIntoView(final long albumId, final ImageView view) {
+        loadAlbumArtIntoView(albumId, view, new SimpleImageLoadingListener());
+    }
+
+    public static void loadAlbumArtIntoView(final long albumId, final ImageView view,
+                                            final ImageLoadingListener listener) {
+        ImageLoader.getInstance()
+                .displayImage(TimberUtils.getAlbumArtUri(albumId).toString(),
+                              view,
+                              diskDisplayImageOptions,
+                              new SimpleImageLoadingListener() {
+                                  @Override
+                                  public void onLoadingFailed(String imageUri, View view,
+                                                              FailReason failReason) {
+                                      loadAlbumArtFromLastfm(albumId, (ImageView) view);
+                                      listener.onLoadingFailed(imageUri, view, failReason);
+                                  }
+                              });
+    }
+
+    private static void loadAlbumArtFromLastfm(long albumId, final ImageView albumArt) {
+        Album album = AlbumLoader.getAlbum(albumArt.getContext(), albumId);
+        LastFmClient.getInstance(albumArt.getContext())
+                .getAlbumInfo(new AlbumQuery(album.title, album.artistName),
+                              new AlbuminfoListener() {
+                                  @Override
+                                  public void albumInfoSucess(final LastfmAlbum album) {
+                                      if (album != null) {
+                                          ImageLoader.getInstance()
+                                                  .displayImage(album.mArtwork.get(4).mUrl,
+                                                                albumArt,
+                                                                lastfmDisplayImageOptions);
+                                      }
+                                  }
+
+                                  @Override
+                                  public void albumInfoFailed() { }
+                              });
+    }
 
     public static Drawable createBlurredImageFromBitmap(Bitmap bitmap, Context context, int inSampleSize) {
 
@@ -48,5 +114,4 @@ public class ImageUtils {
 
         return new BitmapDrawable(context.getResources(), blurTemplate);
     }
-
 }

--- a/app/src/main/java/com/naman14/timber/utils/ImageUtils.java
+++ b/app/src/main/java/com/naman14/timber/utils/ImageUtils.java
@@ -26,7 +26,7 @@ import android.widget.ImageView;
 import com.naman14.timber.R;
 import com.naman14.timber.dataloaders.AlbumLoader;
 import com.naman14.timber.lastfmapi.LastFmClient;
-import com.naman14.timber.lastfmapi.callbacks.AlbuminfoListener;
+import com.naman14.timber.lastfmapi.callbacks.AlbumInfoListener;
 import com.naman14.timber.lastfmapi.models.AlbumQuery;
 import com.naman14.timber.lastfmapi.models.LastfmAlbum;
 import com.naman14.timber.models.Album;
@@ -76,9 +76,9 @@ public class ImageUtils {
         Album album = AlbumLoader.getAlbum(albumArt.getContext(), albumId);
         LastFmClient.getInstance(albumArt.getContext())
                 .getAlbumInfo(new AlbumQuery(album.title, album.artistName),
-                              new AlbuminfoListener() {
+                              new AlbumInfoListener() {
                                   @Override
-                                  public void albumInfoSucess(final LastfmAlbum album) {
+                                  public void albumInfoSuccess(final LastfmAlbum album) {
                                       if (album != null) {
                                           ImageLoader.getInstance()
                                                   .displayImage(album.mArtwork.get(4).mUrl,

--- a/app/src/main/java/com/naman14/timber/utils/ImageUtils.java
+++ b/app/src/main/java/com/naman14/timber/utils/ImageUtils.java
@@ -58,6 +58,15 @@ public class ImageUtils {
 
     public static void loadAlbumArtIntoView(final long albumId, final ImageView view,
                                             final ImageLoadingListener listener) {
+        if (PreferencesUtility.getInstance(view.getContext()).alwaysLoadAlbumImagesFromLastfm()) {
+            loadAlbumArtFromLastfm(albumId, view);
+        } else {
+            loadAlbumArtFromDiskWithLastfmFallback(albumId, view, listener);
+        }
+    }
+
+    private static void loadAlbumArtFromDiskWithLastfmFallback(final long albumId, ImageView view,
+                                                               final ImageLoadingListener listener) {
         ImageLoader.getInstance()
                 .displayImage(TimberUtils.getAlbumArtUri(albumId).toString(),
                               view,

--- a/app/src/main/java/com/naman14/timber/utils/PreferencesUtility.java
+++ b/app/src/main/java/com/naman14/timber/utils/PreferencesUtility.java
@@ -56,8 +56,8 @@ public final class PreferencesUtility {
     public static final String FULL_UNLOCKED = "full_version_unlocked";
 
     private static final String SHOW_LOCKSCREEN_ALBUMART = "show_albumart_lockscreen";
-    private static final String ARTIST_IMAGE = "artist_image";
-    private static final String ARTIST_IMAGE_MOBILE = "artist_image_mobile";
+    private static final String ARTIST_ALBUM_IMAGE = "artist_album_image";
+    private static final String ARTIST_ALBUM_IMAGE_MOBILE = "artist_album_image_mobile";
 
     private static PreferencesUtility sInstance;
 
@@ -274,9 +274,9 @@ public final class PreferencesUtility {
         context.startService(intent);
     }
 
-    public boolean loadArtistImages() {
-        if (mPreferences.getBoolean(ARTIST_IMAGE, true)) {
-            if (!mPreferences.getBoolean(ARTIST_IMAGE_MOBILE, false)) {
+    public boolean loadArtistAndAlbumImages() {
+        if (mPreferences.getBoolean(ARTIST_ALBUM_IMAGE, true)) {
+            if (!mPreferences.getBoolean(ARTIST_ALBUM_IMAGE_MOBILE, false)) {
                 if (connManager == null) connManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
                 NetworkInfo ni = connManager.getActiveNetworkInfo();
                 return ni != null && ni.getType() == ConnectivityManager.TYPE_WIFI;

--- a/app/src/main/java/com/naman14/timber/utils/PreferencesUtility.java
+++ b/app/src/main/java/com/naman14/timber/utils/PreferencesUtility.java
@@ -58,6 +58,7 @@ public final class PreferencesUtility {
     private static final String SHOW_LOCKSCREEN_ALBUMART = "show_albumart_lockscreen";
     private static final String ARTIST_ALBUM_IMAGE = "artist_album_image";
     private static final String ARTIST_ALBUM_IMAGE_MOBILE = "artist_album_image_mobile";
+    private static final String ALWAYS_LOAD_ALBUM_IMAGES_LASTFM = "always_load_album_images_lastfm";
 
     private static PreferencesUtility sInstance;
 
@@ -286,5 +287,8 @@ public final class PreferencesUtility {
         return false;
     }
 
+    public boolean alwaysLoadAlbumImagesFromLastfm() {
+        return mPreferences.getBoolean(ALWAYS_LOAD_ALBUM_IMAGES_LASTFM, false);
+    }
 }
 

--- a/app/src/main/res/layout/fragment_album_detail.xml
+++ b/app/src/main/res/layout/fragment_album_detail.xml
@@ -30,6 +30,7 @@
                 android:layout_height="match_parent"
                 android:fitsSystemWindows="true"
                 android:scaleType="centerCrop"
+                android:src="@drawable/ic_empty_music2"
                 android:transitionName="transition_album_art"
                 app:layout_collapseMode="parallax" />
 

--- a/app/src/main/res/layout/item_artist_album.xml
+++ b/app/src/main/res/layout/item_artist_album.xml
@@ -19,8 +19,8 @@
             android:layout_height="104dp"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:transitionName="transition_album_art"/>
-
+            android:src="@drawable/ic_empty_music2"
+            android:transitionName="transition_album_art" />
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -81,10 +81,10 @@
     <string name="pause_detach">Pause beim entfernen</string>
     <string name="albumart_lockscreen">Sperrbildschirm</string>
     <string name="albumart_lockscreen_summary">Albumcover im Sperrbildschirm anzeigen.</string>
-    <string name="load_artist_image">Interpretenbilder</string>
-    <string name="load_artist_image_summary">Lade Interpretenbilder aus dem Internet.</string>
-    <string name="load_artist_image_mobile">Mobiledaten</string>
-    <string name="load_artist_image_mobile_summary">Interpretenbilder auch ohne Wifi laden.</string>
+    <string name="load_artist_album_image">Interpretenbilder</string>
+    <string name="load_artist_album_image_summary">Lade Interpretenbilder aus dem Internet.</string>
+    <string name="load_artist_album_image_mobile">Mobiledaten</string>
+    <string name="load_artist_album_image_mobile_summary">Interpretenbilder auch ohne Wifi laden.</string>
 
 
     <string name="count_song"><xliff:g id="count">%d</xliff:g> Song</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -104,11 +104,11 @@
     <string name="albumart_lockscreen">锁屏</string>
     <string name="albumart_lockscreen_summary">在锁屏界面显示专辑封面</string>
 
-    <string name="load_artist_image">加载艺术家图像</string>
-    <string name="load_artist_image_summary">从 Last.fm 加载艺术家图像</string>
+    <string name="load_artist_album_image">加载艺术家图像</string>
+    <string name="load_artist_album_image_summary">从 Last.fm 加载艺术家图像</string>
 
-    <string name="load_artist_image_mobile">从设备数据加载艺术家图像</string>
-    <string name="load_artist_image_mobile_summary">无 Wi-Fi 时也能加载艺术家图像</string>
+    <string name="load_artist_album_image_mobile">从设备数据加载艺术家图像</string>
+    <string name="load_artist_album_image_mobile_summary">无 Wi-Fi 时也能加载艺术家图像</string>
 
     <string name="gestures">手势</string>
     <string name="switching_tracks_by_gestures">使用手势切换曲目</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,5 +156,7 @@
     <string name="lastfm_loged_in">Logged in as %s</string>
 
     <string name="cancel">Cancel</string>
+    <string name="always_load_album_images_lastfm">Always load album images from Last.fm</string>
+    <string name="always_load_album_images_lastfm_summary">If unchecked, album art will be fetched locally from song file if available</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,11 +104,11 @@
     <string name="albumart_lockscreen">Lockscreen</string>
     <string name="albumart_lockscreen_summary">Show album art in lockscreen</string>
 
-    <string name="load_artist_image">Load artist images</string>
-    <string name="load_artist_image_summary">Load artist images from lastfm</string>
+    <string name="load_artist_album_image">Load artist/album images</string>
+    <string name="load_artist_album_image_summary">Load artist/album images from lastfm</string>
 
-    <string name="load_artist_image_mobile">Load artist images on mobile data</string>
-    <string name="load_artist_image_mobile_summary">Load artist images even if there is no wifi</string>
+    <string name="load_artist_album_image_mobile">Load artist/album images on mobile data</string>
+    <string name="load_artist_album_image_mobile_summary">Load artist/album images even if there is no wifi</string>
 
     <string name="gestures">Gestures</string>
     <string name="switching_tracks_by_gestures">Switching tracks using gestures</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -125,17 +125,17 @@
 
         <com.afollestad.appthemeengine.prefs.ATECheckBoxPreference
             android:defaultValue="true"
-            android:key="artist_image"
-            android:summary="@string/load_artist_image_summary"
-            android:title="@string/load_artist_image"
+            android:key="artist_album_image"
+            android:summary="@string/load_artist_album_image_summary"
+            android:title="@string/load_artist_album_image"
             app:ateKey_pref_checkBox="?ate_key" />
 
         <com.afollestad.appthemeengine.prefs.ATECheckBoxPreference
-            android:dependency="artist_image"
+            android:dependency="artist_album_image"
             android:defaultValue="false"
-            android:key="artist_image_mobile"
-            android:summary="@string/load_artist_image_mobile_summary"
-            android:title="@string/load_artist_image_mobile"
+            android:key="artist_album_image_mobile"
+            android:summary="@string/load_artist_album_image_mobile_summary"
+            android:title="@string/load_artist_album_image_mobile"
             app:ateKey_pref_checkBox="?ate_key" />
 
     </com.naman14.timber.widgets.ThemedPreferenceCategory>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -138,6 +138,13 @@
             android:title="@string/load_artist_album_image_mobile"
             app:ateKey_pref_checkBox="?ate_key" />
 
+        <com.afollestad.appthemeengine.prefs.ATECheckBoxPreference
+            android:dependency="artist_album_image"
+            android:defaultValue="false"
+            android:key="always_load_album_images_lastfm"
+            android:summary="@string/always_load_album_images_lastfm_summary"
+            android:title="@string/always_load_album_images_lastfm"
+            app:ateKey_pref_checkBox="?ate_key" />
     </com.naman14.timber.widgets.ThemedPreferenceCategory>
 
     <com.naman14.timber.widgets.ThemedPreferenceCategory android:title="@string/advanced">


### PR DESCRIPTION
If an album's art isn't found in the disk or something fails while loading it, this adds downloading it from Lastfm as a fallback. It does so only when listing the albums of an artist (`ArtistMusicFragment`) and when showing the album (`AlbumDetailFragment`).

There are some more places where album art is displayed and could benefit from this change. As they are not as important, I've left them out to keep the pull request small. If this gets merged, I can work on them on another pull request. I would also like to implement downloading the images directly into the folder of the album instead of into the cache of the application.