### PR TITLE
Enforcing nullability contracts in runtime

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,6 @@
+plugins {
+    id "tech.harmonysoft.oss.traute" version "1.1.6"
+}
 apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
 


### PR DESCRIPTION
This *PR* applies [Traute](http://traute.oss.harmonysoft.tech/) to the project. The result is that *Traute* generates runtime *null*-checks based on *NonNull* annotations defined in source code.  

Consider [ATEUtils. applyTaskDescription()](https://github.com/naman14/Timber/blob/master/app/src/main/java/com/naman14/timber/utils/ATEUtils.java#L75) for example:  

*Source code*  

```java
private static void applyTaskDescription(@NonNull Activity activity, @Nullable String key, int color) {
    ...
}
```  

Resulting bytecode looks like if it's compiled from the source below:  

```java
private static void applyTaskDescription(@NonNull Activity activity, @Nullable String key, int color) {
    if (activity == null) {
        throw new NullPointerException("Argument 'activity' of type Activity (#0 out of 3, zero-based) is marked by @android.support.annotation.NonNull but got null for it");
    }
    ...
}
```  
*Raw bytecode*  

```
javap -c -private ./app/build/intermediates/classes/debug/com/naman14/timber/utils/ATEUtils.class
...
  private static void applyTaskDescription(android.app.Activity, java.lang.String, int);
    Code:
       0: aload_0
       1: ifnonnull     14
       4: new           #28                 // class java/lang/NullPointerException
       7: dup
       8: ldc           #29                 // String Argument 'activity' of type Activity (#0 out of 3, zero-based) is marked by @android.support.annotation.NonNull but got null for it
      10: invokespecial #30                 // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      13: athrow
       ...
```