### PR TITLE
Add to queue and add to playlist for albums and artists

### DIFF
--- a/app/src/main/java/com/naman14/timber/MusicPlayer.java
+++ b/app/src/main/java/com/naman14/timber/MusicPlayer.java
@@ -15,6 +15,7 @@
 
 package com.naman14.timber;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.ComponentName;
 import android.content.ContentResolver;
@@ -24,6 +25,7 @@ import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.IBinder;
@@ -38,6 +40,8 @@ import com.naman14.timber.utils.TimberUtils.IdType;
 
 import java.util.Arrays;
 import java.util.WeakHashMap;
+
+import static android.support.v4.content.PermissionChecker.checkSelfPermission;
 
 public class MusicPlayer {
 

--- a/app/src/main/java/com/naman14/timber/activities/MainActivity.java
+++ b/app/src/main/java/com/naman14/timber/activities/MainActivity.java
@@ -220,6 +220,7 @@ public class MainActivity extends BaseActivity implements ATEActivityThemeCustom
 
         if (TimberUtils.isMarshmallow()) {
             checkPermissionAndThenLoad();
+            //checkWritePermissions();
         } else {
             loadEverything();
         }
@@ -277,7 +278,7 @@ public class MainActivity extends BaseActivity implements ATEActivityThemeCustom
 
     private void checkPermissionAndThenLoad() {
         //check for permission
-        if (Nammu.checkPermission(Manifest.permission.READ_EXTERNAL_STORAGE)) {
+        if (Nammu.checkPermission(Manifest.permission.READ_EXTERNAL_STORAGE) && Nammu.checkPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
             loadEverything();
         } else {
             if (Nammu.shouldShowRequestPermissionRationale(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
@@ -286,14 +287,15 @@ public class MainActivity extends BaseActivity implements ATEActivityThemeCustom
                         .setAction("OK", new View.OnClickListener() {
                             @Override
                             public void onClick(View view) {
-                                Nammu.askForPermission(MainActivity.this, Manifest.permission.READ_EXTERNAL_STORAGE, permissionReadstorageCallback);
+                                Nammu.askForPermission(MainActivity.this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, permissionReadstorageCallback);
                             }
                         }).show();
             } else {
-                Nammu.askForPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE, permissionReadstorageCallback);
+                Nammu.askForPermission(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, permissionReadstorageCallback);
             }
         }
     }
+
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {

--- a/app/src/main/java/com/naman14/timber/adapters/ArtistSongAdapter.java
+++ b/app/src/main/java/com/naman14/timber/adapters/ArtistSongAdapter.java
@@ -174,7 +174,7 @@ public class ArtistSongAdapter extends BaseSongAdapter<ArtistSongAdapter.ItemHol
 
     public long[] getSongIds() {
         List<Song> actualArraylist = new ArrayList<Song>(arraylist);
-        actualArraylist.remove(0);
+        //actualArraylist.remove(0);
         long[] ret = new long[actualArraylist.size()];
         for (int i = 0; i < actualArraylist.size(); i++) {
             ret[i] = actualArraylist.get(i).id;

--- a/app/src/main/java/com/naman14/timber/fragments/AlbumDetailFragment.java
+++ b/app/src/main/java/com/naman14/timber/fragments/AlbumDetailFragment.java
@@ -48,6 +48,7 @@ import com.naman14.timber.activities.MainActivity;
 import com.naman14.timber.adapters.AlbumSongsAdapter;
 import com.naman14.timber.dataloaders.AlbumLoader;
 import com.naman14.timber.dataloaders.AlbumSongLoader;
+import com.naman14.timber.dialogs.AddPlaylistDialog;
 import com.naman14.timber.listeners.SimplelTransitionListener;
 import com.naman14.timber.models.Album;
 import com.naman14.timber.models.Song;
@@ -74,6 +75,7 @@ public class AlbumDetailFragment extends Fragment {
 
     private ImageView albumArt, artistArt;
     private TextView albumTitle, albumDetails;
+    private AppCompatActivity mContext;
 
     private RecyclerView recyclerView;
     private AlbumSongsAdapter mAdapter;
@@ -110,6 +112,7 @@ public class AlbumDetailFragment extends Fragment {
             albumID = getArguments().getLong(Constants.ALBUM_ID);
         }
         context = getActivity();
+        mContext = (AppCompatActivity) context;
         mPreferences = PreferencesUtility.getInstance(context);
     }
 
@@ -309,6 +312,12 @@ public class AlbumDetailFragment extends Fragment {
         switch (item.getItemId()) {
             case R.id.menu_go_to_artist:
                 NavigationUtils.goToArtist(getContext(), album.artistId);
+                break;
+            case R.id.popup_song_addto_queue:
+                MusicPlayer.addToQueue(context, mAdapter.getSongIds(), -1, TimberUtils.IdType.NA);
+                break;
+            case R.id.popup_song_addto_playlist:
+                AddPlaylistDialog.newInstance(mAdapter.getSongIds()).show(mContext.getSupportFragmentManager(), "ADD_PLAYLIST");
                 break;
             case R.id.menu_sort_by_az:
                 mPreferences.setAlbumSongSortOrder(SortOrder.AlbumSongSortOrder.SONG_A_Z);

--- a/app/src/main/java/com/naman14/timber/fragments/ArtistDetailFragment.java
+++ b/app/src/main/java/com/naman14/timber/fragments/ArtistDetailFragment.java
@@ -30,25 +30,34 @@ import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 
 import com.afollestad.appthemeengine.ATE;
+import com.naman14.timber.MusicPlayer;
 import com.naman14.timber.R;
+import com.naman14.timber.adapters.ArtistSongAdapter;
 import com.naman14.timber.dataloaders.ArtistLoader;
+import com.naman14.timber.dataloaders.ArtistSongLoader;
+import com.naman14.timber.dialogs.AddPlaylistDialog;
 import com.naman14.timber.lastfmapi.LastFmClient;
 import com.naman14.timber.lastfmapi.callbacks.ArtistInfoListener;
 import com.naman14.timber.lastfmapi.models.ArtistQuery;
 import com.naman14.timber.lastfmapi.models.LastfmArtist;
 import com.naman14.timber.models.Artist;
+import com.naman14.timber.models.Song;
 import com.naman14.timber.utils.ATEUtils;
 import com.naman14.timber.utils.Constants;
 import com.naman14.timber.utils.Helpers;
 import com.naman14.timber.utils.ImageUtils;
+import com.naman14.timber.utils.TimberUtils;
 import com.nostra13.universalimageloader.core.DisplayImageOptions;
 import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.listener.SimpleImageLoadingListener;
+
+import java.util.List;
 
 public class ArtistDetailFragment extends Fragment {
 
@@ -61,6 +70,7 @@ public class ArtistDetailFragment extends Fragment {
     AppBarLayout appBarLayout;
     boolean largeImageLoaded = false;
     int primaryColor = -1;
+    ArtistSongAdapter mAdapter;
 
     public static ArtistDetailFragment newInstance(long id, boolean useTransition, String transitionName) {
         ArtistDetailFragment fragment = new ArtistDetailFragment();
@@ -118,6 +128,8 @@ public class ArtistDetailFragment extends Fragment {
     private void setUpArtistDetails() {
 
         final Artist artist = ArtistLoader.getArtist(getActivity(), artistID);
+        List<Song> songList = ArtistSongLoader.getSongsForArtist(getActivity(), artistID);
+        mAdapter = new ArtistSongAdapter(getActivity(), songList, artistID);
 
         collapsingToolbarLayout.setTitle(artist.name);
 
@@ -200,8 +212,21 @@ public class ArtistDetailFragment extends Fragment {
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
+        inflater.inflate(R.menu.artist_detail, menu);
         if (getActivity() != null)
             ATE.applyMenu(getActivity(), "dark_theme", menu);
+    }
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.popup_song_addto_queue:
+                MusicPlayer.addToQueue(getContext(), mAdapter.getSongIds(), -1, TimberUtils.IdType.NA);
+                break;
+            case R.id.popup_song_addto_playlist:
+                AddPlaylistDialog.newInstance(mAdapter.getSongIds()).show(getActivity().getSupportFragmentManager(), "ADD_PLAYLIST");
+                break;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/src/main/res/menu/album_detail.xml
+++ b/app/src/main/res/menu/album_detail.xml
@@ -4,6 +4,12 @@
         android:id="@+id/menu_go_to_artist"
         android:title="@string/go_to_artist" />
     <item
+        android:id="@+id/popup_song_addto_queue"
+        android:title="@string/add_to_queue" />
+    <item
+        android:id="@+id/popup_song_addto_playlist"
+        android:title="@string/add_to_playlist" />
+    <item
         android:id="@+id/menu_sort_by"
         android:showAsAction="never"
         android:orderInCategory="50"

--- a/app/src/main/res/menu/artist_detail.xml
+++ b/app/src/main/res/menu/artist_detail.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item
+        android:id="@+id/popup_song_addto_queue"
+        android:title="@string/add_to_queue" />
+    <item
+        android:id="@+id/popup_song_addto_playlist"
+        android:title="@string/add_to_playlist"/>
+</menu>


### PR DESCRIPTION
This change adds options to add to queue and add to playlist in the context menus for albums and artists.

This also fixes a bug in permissions where Timber would crash if it didn't have permissions to write to external storage.  Timber now asks for WRITE_EXTERNAL_STORAGE permissions on first boot at the same time it asks for read permissions

![screenshot_20180108-161858](https://user-images.githubusercontent.com/22754714/34693101-76c1a3ba-f490-11e7-8c8d-cd0aaadc5606.png)
![screenshot_20180108-161905](https://user-images.githubusercontent.com/22754714/34693106-7842e0dc-f490-11e7-8f0d-864664e753e9.png)
![screenshot_20180108-161805](https://user-images.githubusercontent.com/22754714/34693108-7aefa0e0-f490-11e7-8ea0-307357a42e9f.png)
![screenshot_20180108-161824](https://user-images.githubusercontent.com/22754714/34693111-7bfdbc60-f490-11e7-9698-e3fe15214b31.png)



