### PR TITLE
Bug fixes

### DIFF
--- a/app/src/main/java/com/naman14/timber/activities/BaseActivity.java
+++ b/app/src/main/java/com/naman14/timber/activities/BaseActivity.java
@@ -170,6 +170,10 @@ public class BaseActivity extends ATEActivity implements ServiceConnection, Musi
             mCastSession = mSessionManager.getCurrentCastSession();
             mSessionManager.addSessionManagerListener(mSessionManagerListener);
         }
+        //For Android 8.0+: service may get destroyed if in background too long
+        if(mService == null){
+            mToken = MusicPlayer.bindToService(this, this);
+        }
         onMetaChanged();
         super.onResume();
     }

--- a/app/src/main/java/com/naman14/timber/activities/MainActivity.java
+++ b/app/src/main/java/com/naman14/timber/activities/MainActivity.java
@@ -286,11 +286,11 @@ public class MainActivity extends BaseActivity implements ATEActivityThemeCustom
                         .setAction("OK", new View.OnClickListener() {
                             @Override
                             public void onClick(View view) {
-                                Nammu.askForPermission(MainActivity.this, Manifest.permission.READ_EXTERNAL_STORAGE, permissionReadstorageCallback);
+                                Nammu.askForPermission(MainActivity.this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, permissionReadstorageCallback);
                             }
                         }).show();
             } else {
-                Nammu.askForPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE, permissionReadstorageCallback);
+                Nammu.askForPermission(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, permissionReadstorageCallback);
             }
         }
     }

--- a/app/src/main/java/com/naman14/timber/adapters/AlbumSongsAdapter.java
+++ b/app/src/main/java/com/naman14/timber/adapters/AlbumSongsAdapter.java
@@ -140,9 +140,15 @@ public class AlbumSongsAdapter extends BaseSongAdapter<AlbumSongsAdapter.ItemHol
         return ret;
     }
 
+    @Override
     public void updateDataSet(List<Song> arraylist) {
         this.arraylist = arraylist;
         this.songIDs = getSongIds();
+    }
+
+    @Override
+    public void removeSongAt(int i){
+        arraylist.remove(i);
     }
 
     public class ItemHolder extends RecyclerView.ViewHolder implements View.OnClickListener {

--- a/app/src/main/java/com/naman14/timber/adapters/ArtistSongAdapter.java
+++ b/app/src/main/java/com/naman14/timber/adapters/ArtistSongAdapter.java
@@ -137,8 +137,8 @@ public class ArtistSongAdapter extends BaseSongAdapter<ArtistSongAdapter.ItemHol
                                 TimberUtils.shareTrack(mContext, arraylist.get(position).id);
                                 break;
                             case R.id.popup_song_delete:
-                                long[] deleteIds = {arraylist.get(position).id};
-                                TimberUtils.showDeleteDialog(mContext,arraylist.get(position).title, deleteIds, ArtistSongAdapter.this, position);
+                                long[] deleteIds = {arraylist.get(position + 1).id};
+                                TimberUtils.showDeleteDialog(mContext,arraylist.get(position + 1).title, deleteIds, ArtistSongAdapter.this, position + 1);
                                 break;
                         }
                         return false;
@@ -180,6 +180,18 @@ public class ArtistSongAdapter extends BaseSongAdapter<ArtistSongAdapter.ItemHol
             ret[i] = actualArraylist.get(i).id;
         }
         return ret;
+    }
+
+    @Override
+    public void removeSongAt(int i){
+        arraylist.remove(i);
+        updateDataSet(arraylist);
+    }
+
+    @Override
+    public void updateDataSet(List<Song> arraylist) {
+        this.arraylist = arraylist;
+        this.songIDs = getSongIds();
     }
 
     @Override

--- a/app/src/main/java/com/naman14/timber/adapters/BaseQueueAdapter.java
+++ b/app/src/main/java/com/naman14/timber/adapters/BaseQueueAdapter.java
@@ -149,6 +149,10 @@ public class BaseQueueAdapter extends RecyclerView.Adapter<BaseQueueAdapter.Item
         return ret;
     }
 
+    public void removeSongAt(int i){
+        arraylist.remove(i);
+    }
+
     public class ItemHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
         protected TextView title, artist;
         protected ImageView albumArt, popupMenu;

--- a/app/src/main/java/com/naman14/timber/adapters/BaseSongAdapter.java
+++ b/app/src/main/java/com/naman14/timber/adapters/BaseSongAdapter.java
@@ -22,6 +22,7 @@ import com.naman14.timber.utils.NavigationUtils;
 import com.naman14.timber.utils.TimberUtils;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Created by naman on 7/12/17.
@@ -79,6 +80,7 @@ public class BaseSongAdapter<V extends RecyclerView.ViewHolder> extends Recycler
 
 
     }
-
+    public void removeSongAt(int i){}
+    public void updateDataSet(List<Song> arraylist) {}
 
 }

--- a/app/src/main/java/com/naman14/timber/adapters/PlayingQueueAdapter.java
+++ b/app/src/main/java/com/naman14/timber/adapters/PlayingQueueAdapter.java
@@ -109,10 +109,6 @@ public class PlayingQueueAdapter extends RecyclerView.Adapter<PlayingQueueAdapte
                             case R.id.popup_song_addto_playlist:
                                 AddPlaylistDialog.newInstance(arraylist.get(position)).show(((AppCompatActivity) mContext).getSupportFragmentManager(), "ADD_PLAYLIST");
                                 break;
-                            case R.id.popup_song_delete:
-                                long[] deleteIds = {arraylist.get(position).id};
-                                TimberUtils.showDeleteDialog(mContext,arraylist.get(position).title, deleteIds, PlayingQueueAdapter.this,position);
-                                break;
                         }
                         return false;
                     }

--- a/app/src/main/java/com/naman14/timber/adapters/SearchAdapter.java
+++ b/app/src/main/java/com/naman14/timber/adapters/SearchAdapter.java
@@ -188,6 +188,9 @@ public class SearchAdapter extends BaseSongAdapter<SearchAdapter.ItemHolder> {
                     }
                 });
                 menu.inflate(R.menu.popup_song);
+                //Hide these because they aren't implemented
+                menu.getMenu().findItem(R.id.popup_song_delete).setVisible(false);
+                menu.getMenu().findItem(R.id.popup_song_share).setVisible(false);
                 menu.show();
             }
         });

--- a/app/src/main/java/com/naman14/timber/adapters/SongsListAdapter.java
+++ b/app/src/main/java/com/naman14/timber/adapters/SongsListAdapter.java
@@ -219,6 +219,7 @@ public class SongsListAdapter extends BaseSongAdapter<SongsListAdapter.ItemHolde
         }
     }
 
+    @Override
     public void updateDataSet(List<Song> arraylist) {
         this.arraylist = arraylist;
         this.songIDs = getSongIds();
@@ -272,8 +273,10 @@ public class SongsListAdapter extends BaseSongAdapter<SongsListAdapter.ItemHolde
         arraylist.add(i, song);
     }
 
+    @Override
     public void removeSongAt(int i) {
         arraylist.remove(i);
+        updateDataSet(arraylist);
     }
 }
 

--- a/app/src/main/java/com/naman14/timber/utils/TimberUtils.java
+++ b/app/src/main/java/com/naman14/timber/utils/TimberUtils.java
@@ -38,6 +38,8 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.naman14.timber.MusicPlayer;
 import com.naman14.timber.R;
+import com.naman14.timber.adapters.BaseQueueAdapter;
+import com.naman14.timber.adapters.BaseSongAdapter;
 import com.naman14.timber.provider.RecentStore;
 import com.naman14.timber.provider.SongPlayCount;
 
@@ -228,7 +230,7 @@ public class TimberUtils {
                 .setLastAddedCutoff(System.currentTimeMillis());
     }
 
-    public static void showDeleteDialog(final Context context, final String name, final long[] list, final RecyclerView.Adapter adapter, final int pos) {
+    public static void showDeleteDialog(final Context context, final String name, final long[] list, final BaseSongAdapter adapter, final int pos) {
 
         new MaterialDialog.Builder(context)
                 .title("Delete song?")
@@ -239,7 +241,9 @@ public class TimberUtils {
                     @Override
                     public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
                         TimberUtils.deleteTracks(context, list);
+                        adapter.removeSongAt(pos);
                         adapter.notifyItemRemoved(pos);
+                        adapter.notifyItemRangeChanged(pos, adapter.getItemCount());
                     }
                 })
                 .onNegative(new MaterialDialog.SingleButtonCallback() {
@@ -249,10 +253,34 @@ public class TimberUtils {
                     }
                 })
                 .show();
-
-
-
     }
+
+    public static void showDeleteDialog(final Context context, final String name, final long[] list, final BaseQueueAdapter qAdapter, final int pos) {
+
+        new MaterialDialog.Builder(context)
+                .title("Delete song?")
+                .content("Are you sure you want to delete " + name + " ?")
+                .positiveText("Delete")
+                .negativeText("Cancel")
+                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                    @Override
+                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                        TimberUtils.deleteTracks(context, list);
+                        qAdapter.removeSongAt(pos);
+                        qAdapter.notifyItemRemoved(pos);
+                        qAdapter.notifyItemRangeChanged(pos, qAdapter.getItemCount());
+                    }
+                })
+                .onNegative(new MaterialDialog.SingleButtonCallback() {
+                    @Override
+                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                        dialog.dismiss();
+                    }
+                })
+                .show();
+    }
+
+
     public static void deleteTracks(final Context context, final long[] list) {
         final String[] projection = new String[]{
                 BaseColumns._ID, MediaStore.MediaColumns.DATA, MediaStore.Audio.AudioColumns.ALBUM_ID


### PR DESCRIPTION
This PR fixes several bugs.

- Permissions
Timber now asks for write storage permission along with read storage permission to prevent crashing when creating playlists or deleting songs.

-Deleting Songs
The list from which the song was deleted from now properly updates to remove the song.  Removed delete methods from some activities that were unused anyways (such as the playing queue).

-Music Service on Android 8.0
MusicService is now recreated when destroyed by Android System in new revisions of Android. See https://www.youtube.com/watch?v=YtWK9Lyeh4c for a more in-depth explanation.
