### PR TITLE
Add a Global Playing Queue Button

### DIFF
--- a/app/src/main/java/com/naman14/timber/activities/BaseActivity.java
+++ b/app/src/main/java/com/naman14/timber/activities/BaseActivity.java
@@ -305,6 +305,9 @@ public class BaseActivity extends ATEActivity implements ServiceConnection, Musi
             case R.id.action_search:
                 NavigationUtils.navigateToSearch(this);
                 return true;
+            case R.id.action_open_queue:
+                NavigationUtils.goToQueue(this);
+                return true;
             case R.id.action_equalizer:
                 NavigationUtils.navigateToEqualizer(this);
                 return true;

--- a/app/src/main/java/com/naman14/timber/activities/MainActivity.java
+++ b/app/src/main/java/com/naman14/timber/activities/MainActivity.java
@@ -138,6 +138,15 @@ public class MainActivity extends BaseActivity implements ATEActivityThemeCustom
         }
     };
 
+    private Runnable navigateQueueAnywhere = new Runnable(){
+      public void run(){
+          Fragment fragment = new QueueFragment();
+          FragmentManager fragmentManager = getSupportFragmentManager();
+          fragmentManager.beginTransaction()
+                  .replace(R.id.fragment_container,fragment).commit();
+      }
+    };
+
     private Runnable navigateArtist = new Runnable() {
         public void run() {
             long artistID = getIntent().getExtras().getLong(Constants.ARTIST_ID);
@@ -194,6 +203,7 @@ public class MainActivity extends BaseActivity implements ATEActivityThemeCustom
         navigationMap.put(Constants.NAVIGATE_ALBUM, navigateAlbum);
         navigationMap.put(Constants.NAVIGATE_ARTIST, navigateArtist);
         navigationMap.put(Constants.NAVIGATE_LYRICS, navigateLyrics);
+        navigationMap.put(Constants.NAVIGATE_QUEUE_ANYWHERE, navigateQueueAnywhere);
 
         mDrawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
         panelLayout = (SlidingUpPanelLayout) findViewById(R.id.sliding_layout);

--- a/app/src/main/java/com/naman14/timber/activities/MainActivity.java
+++ b/app/src/main/java/com/naman14/timber/activities/MainActivity.java
@@ -308,7 +308,15 @@ public class MainActivity extends BaseActivity implements ATEActivityThemeCustom
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
-
+        Fragment currentFragment = getSupportFragmentManager().findFragmentById(R.id.fragment_container);
+        if(currentFragment instanceof QueueFragment){
+            MenuItem item = menu.findItem(R.id.action_open_queue);
+            item.setVisible(false);
+        }
+        else{
+            MenuItem item = menu.findItem(R.id.action_open_queue);
+            item.setVisible(true);
+        }
         return true;
     }
 

--- a/app/src/main/java/com/naman14/timber/utils/Constants.java
+++ b/app/src/main/java/com/naman14/timber/utils/Constants.java
@@ -19,6 +19,7 @@ public class Constants {
     public static final String NAVIGATE_LIBRARY = "navigate_library";
     public static final String NAVIGATE_PLAYLIST = "navigate_playlist";
     public static final String NAVIGATE_QUEUE = "navigate_queue";
+    public static final String NAVIGATE_QUEUE_ANYWHERE = "navigate_queue_anywhere";
     public static final String NAVIGATE_ALBUM = "navigate_album";
     public static final String NAVIGATE_ARTIST = "navigate_artist";
     public static final String NAVIGATE_NOWPLAYING = "navigate_nowplaying";

--- a/app/src/main/java/com/naman14/timber/utils/NavigationUtils.java
+++ b/app/src/main/java/com/naman14/timber/utils/NavigationUtils.java
@@ -94,6 +94,12 @@ public class NavigationUtils {
         context.startActivity(intent);
     }
 
+    public static void goToQueue(Context context){
+        Intent intent = new Intent(context, MainActivity.class);
+        intent.setAction(Constants.NAVIGATE_QUEUE_ANYWHERE);
+        context.startActivity(intent);
+    }
+
     public static void goToLyrics(Context context) {
         Intent intent = new Intent(context, MainActivity.class);
         intent.setAction(Constants.NAVIGATE_LYRICS);

--- a/app/src/main/res/drawable/ic_queue_music_black_24px.xml
+++ b/app/src/main/res/drawable/ic_queue_music_black_24px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M15,6L3,6v2h12L15,6zM15,10L3,10v2h12v-2zM3,16h8v-2L3,14v2zM17,6v8.18c-0.31,-0.11 -0.65,-0.18 -1,-0.18 -1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3L19,8h3L22,6h-5z"
+        android:fillColor="#FFFFFF"/>
+</vector>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -13,9 +13,16 @@
 
     <item
         android:id="@+id/action_search"
-        android:orderInCategory="1"
+        android:orderInCategory="2"
         android:icon="@drawable/ic_action_search"
         app:showAsAction="always"
         android:title="@string/search"/>
+
+    <item
+        android:id="@+id/action_open_queue"
+        android:orderInCategory="1"
+        android:icon="@drawable/ic_queue_music_black_24px"
+        app:showAsAction="always"
+        android:title="@string/playing_queue"/>
 
 </menu>


### PR DESCRIPTION
This PR adds a global playing queue button in the top application bar that makes it easy to get to the playing queue from almost anywhere in the app.  This makes it very easy to get to the queue to arrange items.  The playing queue button disappears when the playing queue is open.
![screenshot_20180124-134610](https://user-images.githubusercontent.com/22754714/35351776-f233edc4-010f-11e8-9bc3-09112873e927.png)
![screenshot_20180124-134654](https://user-images.githubusercontent.com/22754714/35351779-f32c1cd8-010f-11e8-9cd2-1da8714f2437.png)
![screenshot_20180124-134646](https://user-images.githubusercontent.com/22754714/35351780-f41cee6a-010f-11e8-90eb-65aa2c9a18d6.png)

