### PR TITLE
Fix rearranging songs in a playlist

### DIFF
--- a/app/src/main/java/com/naman14/timber/adapters/SongsListAdapter.java
+++ b/app/src/main/java/com/naman14/timber/adapters/SongsListAdapter.java
@@ -271,6 +271,7 @@ public class SongsListAdapter extends BaseSongAdapter<SongsListAdapter.ItemHolde
 
     public void addSongTo(int i, Song song) {
         arraylist.add(i, song);
+        updateDataSet(arraylist);
     }
 
     @Override


### PR DESCRIPTION
Simple fix for reordering items in a playlist. Ensures that the correct song is played when selected after rearranging.