### PR TITLE
Change in LastFmLoginDialog creation

### DIFF
--- a/app/src/main/java/com/naman14/timber/fragments/SettingsFragment.java
+++ b/app/src/main/java/com/naman14/timber/fragments/SettingsFragment.java
@@ -165,8 +165,7 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
                     updateLastFM();
                 } else {
                     LastFmLoginDialog lastFmLoginDialog = new LastFmLoginDialog();
-                    lastFmLoginDialog.setTargetFragment(SettingsFragment.this, 0);
-                    lastFmLoginDialog.show(getFragmentManager(), LastFmLoginDialog.FRAGMENT_NAME);
+                    lastFmLoginDialog.show(getChildFragmentManager(), LastFmLoginDialog.FRAGMENT_NAME);
 
                 }
                 return true;


### PR DESCRIPTION
getFragmentManager() will return the hosting Activity's FragmentManager. Instead, getChildFragmentManager() will return the hosting Fragment's FragmentManager.. It is important to use getChildFragmentManager() because you're nesting a Fragment inside another Fragment, so the parent Fragment should be in charge of handling any transactions with the nested Fragment.

(chenk this question at stakoverflow)[https://stackoverflow.com/questions/10436120/failure-saving-state-target-not-in-fragment-manager-settargetfragment]