### PR TITLE
Add support for CR-ended embed lyrics and some Simplified Chinese strings

### DIFF
--- a/app/src/main/java/com/naman14/timber/utils/LyricsExtractor.java
+++ b/app/src/main/java/com/naman14/timber/utils/LyricsExtractor.java
@@ -15,20 +15,29 @@ public class LyricsExtractor {
     public static String getLyrics(File file){
         String filename = file.getName();
         String fileending = filename.substring(filename.lastIndexOf('.')+1,filename.length()).toLowerCase();
+        String lyric = null;
         try{
             switch(fileending){
                 case "mp3":
-                    return getLyricsID3(file);
+                    lyric = getLyricsID3(file);
+                    break;
                 case "mp4":
                 case "m4a":
                 case "aac":
-                    return getLyricsMP4(file);
+                    lyric = getLyricsMP4(file);
+                    break;
                 case "ogg":
                 case "oga":
-                    return getLyricsVorbis(file);
+                    lyric = getLyricsVorbis(file);
+                    break;
             }
         }catch(Exception e){}
-        return null;
+        /* iTunes and some music manager use CR as newline, we replace CRLF and CR to LF to ensure it
+        * be correctly displayed */
+        if (lyric != null) {
+            lyric = lyric.replace("\r\n", "\n").replace("\r", "\n");
+        }
+        return lyric;
     }
 
     private static int readOgg(byte[] buf, InputStream in, int bytesinpage, int skip) throws IOException {

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -149,4 +149,10 @@
 
     <string name="cancel">取消</string>
 
+    <string name="menu_show_lyrics">显示歌词</string>
+    <string name="no_lyrics">找不到歌词</string>
+    <string name="lyrics_makeitpersonal">歌词由 <a href="https://makeitpersonal.co/">makeitpersonal.co</a>提供</string>
+    <string name="cast">Cast</string>
+    <string name="now_playing_no_track_selected">\"没有选中的播放中曲目</string>
+    <string name="lyrics_loading">加载中...</string>
 </resources>


### PR DESCRIPTION
iTunes and some music managers use CR as newline, this will make the lyrics shown on one line.
This patch tries to replace CRLF and CR to LF, which improves the lyric compatibility of this app.
I also added some localization strings for Simplified Chinese.